### PR TITLE
ReferenceTrimmer fixes

### DIFF
--- a/samples/NuGetPackage/NuGetPackage.csproj
+++ b/samples/NuGetPackage/NuGetPackage.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Library</OutputType>
     <RootNamespace>MartinCostello.BuildKit.NuGetPackage</RootNamespace>
     <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/src/BuildKit/MartinCostello.BuildKit.csproj
+++ b/src/BuildKit/MartinCostello.BuildKit.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\build\**\*" Pack="True" PackagePath="build" />
+    <None Include="$(MSBuildThisFileDirectory)\buildMultiTargeting\**\*" Pack="True" PackagePath="buildMultiTargeting" />
     <None Include="$(MSBuildThisFileDirectory)\buildTransitive\**\*" Pack="True" PackagePath="buildTransitive" />
   </ItemGroup>
 </Project>

--- a/src/BuildKit/build/Analyzers.props
+++ b/src/BuildKit/build/Analyzers.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableStyleCopAnalyzers)' == 'true' ">
     <_StyleCopSettingsFileName>stylecop.json</_StyleCopSettingsFileName>
-    <_StyleCopSettings>$(ProjectDir)\$(_StyleCopSettingsFileName)</_StyleCopSettings>
+    <_StyleCopSettings>$([System.IO.Path]::Combine($(ProjectDir), '$(_StyleCopSettingsFileName)'))</_StyleCopSettings>
     <_StyleCopSettings Condition="!Exists('$(_StyleCopSettings)')">$([System.IO.Path]::Combine($(ProjectDir), '..', '..', '$(_StyleCopSettingsFileName)'))</_StyleCopSettings>
   </PropertyGroup>
   <ItemGroup Condition="Exists('$(_StyleCopSettings)')">

--- a/src/BuildKit/build/Analyzers.props
+++ b/src/BuildKit/build/Analyzers.props
@@ -6,10 +6,6 @@
     <EnableStyleCopAnalyzers>$([MSBuild]::ValueOrDefault('$(EnableStyleCopAnalyzers)', 'true'))</EnableStyleCopAnalyzers>
     <EnforceCodeStyleInBuild>$([MSBuild]::ValueOrDefault('$(EnforceCodeStyleInBuild)', 'true'))</EnforceCodeStyleInBuild>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' == 'true' AND '$(GenerateDocumentationFile)' == 'false' ">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);419;1570;1573;1574;1584;1591;SA1600;SA1602</NoWarn>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(GenerateDocumentationFile)' != 'true' ">
     <NoWarn>$(NoWarn);SA0001;SA1600</NoWarn>
   </PropertyGroup>

--- a/src/BuildKit/buildMultiTargeting/MartinCostello.BuildKit.props
+++ b/src/BuildKit/buildMultiTargeting/MartinCostello.BuildKit.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project>
+  <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'build', '$(MSBuildThisFile)'))" />
+</Project>

--- a/src/BuildKit/buildMultiTargeting/MartinCostello.BuildKit.targets
+++ b/src/BuildKit/buildMultiTargeting/MartinCostello.BuildKit.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project>
+  <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'build', '$(MSBuildThisFile)'))" />
+</Project>


### PR DESCRIPTION
- Add targets for `buildMultiTargeting`.
- Combine path correctly.
- Remove references to ReferenceTrimmer as it doesn't seem to be able to dynamically tweak it from inner targets.
