### PR TITLE
Set more test defaults

### DIFF
--- a/src/BuildKit/build/Packages.targets
+++ b/src/BuildKit/build/Packages.targets
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
   <PropertyGroup>
+    <EnablePackageValidation>$([MSBuild]::ValueOrDefault('$(EnablePackageValidation)', 'true'))</EnablePackageValidation>
+  </PropertyGroup>
+  <PropertyGroup>
     <_PackageIconFullPath>$(ProjectDir)\$(PackageIcon)</_PackageIconFullPath>
     <_PackageIconFullPath Condition="!Exists('$(_PackageIconFullPath)')">$([System.IO.Path]::Combine($(ProjectDir), '..', '..', '$(PackageIcon)'))</_PackageIconFullPath>
     <_PackageReadmeFullPath>$(ProjectDir)\$(PackageReadmeFile)</_PackageReadmeFullPath>

--- a/src/BuildKit/build/Packages.targets
+++ b/src/BuildKit/build/Packages.targets
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <EnablePackageValidation>$([MSBuild]::ValueOrDefault('$(EnablePackageValidation)', 'true'))</EnablePackageValidation>
+    <Title>$([MSBuild]::ValueOrDefault('$(Title)', '$(PackageId)'))</Title>
   </PropertyGroup>
   <PropertyGroup>
     <_PackageIconFullPath>$(ProjectDir)\$(PackageIcon)</_PackageIconFullPath>

--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -10,6 +10,9 @@
     <Using Include="Xunit.Abstractions" />
   </ItemGroup>
   <PropertyGroup>
+    <NoWarn>$(NoWarn);CA1062;CA1308;CA1707;CA1711;CA1812;CA1861;CA2007</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);SA0001;SA1600</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
- Suppress more analyzer warnings by default for tests.
- Set `EnablePackageValidation=true` by default for packable projects.
- Default the `Title` property to the same value as `PackageId`.
