### PR TITLE
Remove EnablePackageValidation

### DIFF
--- a/src/BuildKit/build/Packages.targets
+++ b/src/BuildKit/build/Packages.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
   <PropertyGroup>
-    <EnablePackageValidation>$([MSBuild]::ValueOrDefault('$(EnablePackageValidation)', 'true'))</EnablePackageValidation>
     <Title>$([MSBuild]::ValueOrDefault('$(Title)', '$(PackageId)'))</Title>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Declaring it in a shared target seems to make it run to early, so it tries to run before the baseline NuGet packages has been downloaded, causing it to fail.

See https://github.com/martincostello/dotnet-bumper/pull/632.