### PR TITLE
Inspect container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,7 @@ jobs:
       if: runner.os == 'Linux'
       env:
         CONTAINER_TAG: ${{ steps.publish-container.outputs.container-tag }}
-      run: |
-        docker pull "${CONTAINER_TAG}" && docker inspect "${CONTAINER_TAG}"
+      run: docker inspect "${CONTAINER_TAG}"
 
     - name: Generate SBOM
       uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       id: publish-container
       if: runner.os == 'Linux'
       run: |
-        dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer -p:SetGitHubContainerOutputs=true -v:diag
+        dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer -p:SetGitHubContainerPublishingOutputs=true
 
     - name: Inspect container
       if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       id: publish-container
       if: runner.os == 'Linux'
       run: |
-        dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer -p:SetGitHubContainerOutputs=true
+        dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer -p:SetGitHubContainerOutputs=true -v:diag
 
     - name: Inspect container
       if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
     - name: Publish container
       id: publish-container
       if: runner.os == 'Linux'
+      env:
+        SetGitHubContainerOutputs: true
       run: |
         dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,13 @@ jobs:
       run: |
         dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer
 
+    - name: Inspect container
+      if: runner.os == 'Linux'
+      env:
+        CONTAINER_TAG: ${{ steps.publish-container.outputs.container-tag }}
+      run: |
+        docker pull "${CONTAINER_TAG}" && docker inspect "${CONTAINER_TAG}"
+
     - name: Generate SBOM
       uses: anchore/sbom-action@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,10 +77,8 @@ jobs:
     - name: Publish container
       id: publish-container
       if: runner.os == 'Linux'
-      env:
-        SetGitHubContainerOutputs: true
       run: |
-        dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer
+        dotnet publish ./samples/ContainerApp --arch x64 --os linux -p:PublishProfile=DefaultContainer -p:SetGitHubContainerOutputs=true
 
     - name: Inspect container
       if: runner.os == 'Linux'

--- a/src/BuildKit/build/Containers.props
+++ b/src/BuildKit/build/Containers.props
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
   <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' ">
+    <ContainerAuthors>$([MSBuild]::ValueOrDefault('$(ContainerAuthors)', '$(GITHUB_REPOSITORY_OWNER)'))</ContainerAuthors>
+    <ContainerDescription>$([MSBuild]::ValueOrDefault('$(ContainerDescription)', '$(GitHubRepositoryUrl)'))</ContainerDescription>
     <ContainerImageTags>github-$(GITHUB_RUN_NUMBER)</ContainerImageTags>
     <ContainerImageTags Condition=" '$(GitHubPullRequest)' == '' ">$(ContainerImageTags);latest</ContainerImageTags>
-    <ContainerRepository>$(GITHUB_REPOSITORY)</ContainerRepository>
-    <ContainerTitle>$(GITHUB_REPOSITORY)</ContainerTitle>
-    <ContainerVendor>$(GITHUB_REPOSITORY_OWNER)</ContainerVendor>
-    <ContainerVersion>$(GITHUB_SHA)</ContainerVersion>
-    <Description>$([MSBuild]::ValueOrDefault('$(Description)', '$(GitHubRepositoryUrl)'))</Description>
+    <ContainerRepository>$([MSBuild]::ValueOrDefault('$(ContainerRepository)', '$(GITHUB_REPOSITORY)'))</ContainerRepository>
+    <ContainerTitle>$([MSBuild]::ValueOrDefault('$(ContainerTitle)', '$(GITHUB_REPOSITORY)'))</ContainerTitle>
+    <ContainerVendor>$([MSBuild]::ValueOrDefault('$(ContainerVendor)', '$(GITHUB_REPOSITORY_OWNER)'))</ContainerVendor>
+    <ContainerVersion>$([MSBuild]::ValueOrDefault('$(ContainerVersion)', '$(GITHUB_SHA)'))</ContainerVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(IsGitHubActions)' == 'true' ">
     <ContainerLabel Include="com.docker.extension.changelog" Value="$(GitHubRepositoryUrl)/commit/$(GITHUB_SHA)" />

--- a/src/BuildKit/build/Containers.targets
+++ b/src/BuildKit/build/Containers.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <Target Name="SetGitHubContainerOutputs" AfterTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND '$(ContainerRegistry)' != '' ">
+  <Target Name="SetGitHubContainerOutputs" AfterTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND ('$(ContainerRegistry)' != '' OR '$(SetGitHubContainerPublishingOutputs)' == 'true') ">
     <PropertyGroup>
       <_ContainerImage>$(ContainerRegistry)/$(ContainerRepository)</_ContainerImage>
       <_ContainerImage>$(_ContainerImage.ToLowerInvariant())</_ContainerImage>

--- a/src/BuildKit/build/Containers.targets
+++ b/src/BuildKit/build/Containers.targets
@@ -2,7 +2,8 @@
 <Project>
   <Target Name="SetGitHubContainerOutputs" AfterTargets="PublishContainer"  DependsOnTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND ('$(ContainerRegistry)' != '' OR '$(SetGitHubContainerPublishingOutputs)' == 'true') ">
     <PropertyGroup>
-      <_ContainerImage>$(ContainerRegistry)/$(ContainerRepository)</_ContainerImage>
+      <_ContainerImage Condition=" '$(ContainerRegistry)' == '' ">$(ContainerRepository)</_ContainerImage>
+      <_ContainerImage Condition=" '$(ContainerRegistry)' != '' ">$(ContainerRegistry)/$(ContainerRepository)</_ContainerImage>
       <_ContainerImage>$(_ContainerImage.ToLowerInvariant())</_ContainerImage>
       <_ContainerTag>$(_ContainerImage):github-$(GITHUB_RUN_NUMBER)</_ContainerTag>
     </PropertyGroup>

--- a/src/BuildKit/build/Containers.targets
+++ b/src/BuildKit/build/Containers.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <Target Name="SetGitHubContainerOutputs" DependsOnTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND ('$(ContainerRegistry)' != '' OR '$(SetGitHubContainerPublishingOutputs)' == 'true') ">
+  <Target Name="SetGitHubContainerOutputs" AfterTargets="PublishContainer"  DependsOnTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND ('$(ContainerRegistry)' != '' OR '$(SetGitHubContainerPublishingOutputs)' == 'true') ">
     <PropertyGroup>
       <_ContainerImage>$(ContainerRegistry)/$(ContainerRepository)</_ContainerImage>
       <_ContainerImage>$(_ContainerImage.ToLowerInvariant())</_ContainerImage>

--- a/src/BuildKit/build/Containers.targets
+++ b/src/BuildKit/build/Containers.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
-  <Target Name="SetGitHubContainerOutputs" AfterTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND ('$(ContainerRegistry)' != '' OR '$(SetGitHubContainerPublishingOutputs)' == 'true') ">
+  <Target Name="SetGitHubContainerOutputs" DependsOnTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' AND ('$(ContainerRegistry)' != '' OR '$(SetGitHubContainerPublishingOutputs)' == 'true') ">
     <PropertyGroup>
       <_ContainerImage>$(ContainerRegistry)/$(ContainerRepository)</_ContainerImage>
       <_ContainerImage>$(_ContainerImage.ToLowerInvariant())</_ContainerImage>


### PR DESCRIPTION
- Inspect the container in the build to make it easier to validate the publishing is working as intended.
- Add flag to force container outputs to be set in GitHub Actions.
- Fix clobbering of some container tags so they can overridden.
- Fix incorrect default container author.