### PR TITLE
Exclude generated files

### DIFF
--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -32,6 +32,7 @@
     <CoverletExclude Include="$([MSBuild]::Escape('[*.Test*]*'))" />
     <CoverletExclude Include="$([MSBuild]::Escape('[xunit.*]*'))" />
     <CoverletExcludeByAttribute Include="GeneratedCodeAttribute" />
+    <CoverletExcludeByFile Include="$([MSBuild]::Escape('$(ArtifactsPath)/obj/**/*'))" />
   </ItemGroup>
   <UsingTask TaskName="WriteLinesToFileWithRetry" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>


### PR DESCRIPTION
Exclude source-generated files from coverage to avoid warnings/errors from Coverlet/ReportGenerator about files that no longer exist (because they never did).
