### PR TITLE
Add default strong-name key

### DIFF
--- a/src/BuildKit/build/Build.props
+++ b/src/BuildKit/build/Build.props
@@ -18,7 +18,9 @@
     <GenerateDocumentationFile>$([MSBuild]::ValueOrDefault('$(GenerateDocumentationFile)', 'true'))</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AssemblyOriginatorKeyFile)' != '' ">
+    <_DefaultStrongNamePublicKey>00240000048000009400000006020000002400005253413100040000010001004b0b2efbada897147aa03d2076278890aefe2f8023562336d206ec8a719b06e89461c31b43abec615918d509158629f93385930c030494509e418bf396d69ce7dbe0b5b2db1a81543ab42777cb98210677fed69dbeb3237492a7ad69e87a1911ed20eb2d7c300238dc6f6403e3d04a1351c5cb369de4e022b18fbec70f7d21ed</_DefaultStrongNamePublicKey>
     <SignAssembly>$([MSBuild]::ValueOrDefault('$(SignAssembly)', 'true'))</SignAssembly>
     <PublicSign Condition=" !$([System.OperatingSystem]::IsWindows()) AND '$(SignAssembly)' == 'true' ">true</PublicSign>
+    <StrongNamePublicKey Condition=" '$(SignAssembly)' == 'true' ">$([MSBuild]::ValueOrDefault('$(StrongNamePublicKey)', '$(_DefaultStrongNamePublicKey)'))</StrongNamePublicKey>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Add a default value for the strong-name public key to use, as I think the same key is in every project anyway.
