### PR TITLE
Public API analyzers and native AoT

### DIFF
--- a/src/BuildKit/build/Packages.props
+++ b/src/BuildKit/build/Packages.props
@@ -16,4 +16,7 @@
     <PackageRequireLicenseAcceptance>$([MSBuild]::ValueOrDefault('$(PackageRequireLicenseAcceptance)', 'false'))</PackageRequireLicenseAcceptance>
     <SymbolPackageFormat>$([MSBuild]::ValueOrDefault('$(SymbolPackageFormat)', 'snupkg'))</SymbolPackageFormat>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>$([MSBuild]::ValueOrDefault('$(IsAotCompatible)', 'true'))</IsAotCompatible>
+  </PropertyGroup>
 </Project>

--- a/src/BuildKit/build/Packages.targets
+++ b/src/BuildKit/build/Packages.targets
@@ -13,6 +13,21 @@
     <None Condition="Exists('$(_PackageIconFullPath)')" Include="$(_PackageIconFullPath)" Pack="True" PackagePath="" />
     <None Condition="Exists('$(_PackageReadmeFullPath)')" Include="$(_PackageReadmeFullPath)" Pack="True" PackagePath="" />
   </ItemGroup>
+  <ItemGroup Condition="@(PackageReference-&gt;AnyHaveMetadataValue(`Identity`, `Microsoft.CodeAnalysis.PublicApiAnalyzers`))">
+    <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup Condition="@(PackageReference-&gt;AnyHaveMetadataValue(`Identity`, `Microsoft.CodeAnalysis.PublicApiAnalyzers`)) AND Exists('PublicAPI\$(TargetFramework)')">
+    <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <PropertyGroup>
+    <_TargetFrameworkIdentifier>$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))</_TargetFrameworkIdentifier>
+  </PropertyGroup>
+  <ItemGroup Condition="@(PackageReference-&gt;AnyHaveMetadataValue(`Identity`, `Microsoft.CodeAnalysis.PublicApiAnalyzers`)) AND Exists('PublicAPI\$(_TargetFrameworkIdentifier)')">
+    <AdditionalFiles Include="PublicAPI\$(_TargetFrameworkIdentifier)\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\$(_TargetFrameworkIdentifier)\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
   <Target Name="SetNuGetPackageOutputs" AfterTargets="Pack" Condition=" '$(GITHUB_OUTPUT)' != '' ">
     <PropertyGroup>
       <_PackageNamesPath>$(ArtifactsPath)\package-names.txt</_PackageNamesPath>


### PR DESCRIPTION
- Automatically mark packages as native AoT compatible when targeting .NET 8 or later.
- Automatically include Public API baseline files when `Microsoft.CodeAnalysis.PublicApiAnalyzers` is referenced.
