### PR TITLE
Ignore deterministic artifacts path

### DIFF
--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -30,6 +30,7 @@
     <CoverletExclude Include="$([MSBuild]::Escape('[xunit.*]*'))" />
     <CoverletExcludeByAttribute Include="GeneratedCodeAttribute" />
     <CoverletExcludeByFile Include="$([MSBuild]::Escape('$(ArtifactsPath)/obj/**/*'))" />
+    <CoverletExcludeByFile Include="$([MSBuild]::Escape('/_/artifacts/obj/**/*'))" />
     <CoverletOutputFormats Include="cobertura" />
     <CoverletOutputFormats Include="json" />
   </ItemGroup>


### PR DESCRIPTION
Also ignore the `obj` folder for source-generated files when the path is deterministic (i.e. starts with `/_/`).

[For example](https://github.com/martincostello/dependabot-helper/actions/runs/13786013620/job/38554110508#step:9:178):

```text
2025-03-11T10:41:28: File '/_/artifacts/obj/DependabotHelper/release/RazorSlices.SourceGenerator/RazorSlices.SourceGenerator.RazorSliceProxyGenerator/MartinCostello.DependabotHelper.RazorSliceProxies.g.cs' does not exist (any more).
2025-03-11T10:41:28: File '/_/artifacts/obj/DependabotHelper/release/RazorSlices.SourceGenerator/RazorSlices.SourceGenerator.RazorSliceProxyGenerator/MartinCostello.DependabotHelper.RazorSliceProxies.g.cs' does not exist (any more).
2025-03-11T10:41:28: File '/_/artifacts/obj/DependabotHelper/release/RazorSlices.SourceGenerator/RazorSlices.SourceGenerator.RazorSliceProxyGenerator/MartinCostello.DependabotHelper.RazorSliceProxies.g.cs' does not exist (any more).
2025-03-11T10:41:28: File '/_/artifacts/obj/DependabotHelper/release/RazorSlices.SourceGenerator/RazorSlices.SourceGenerator.RazorSliceProxyGenerator/MartinCostello.DependabotHelper.RazorSliceProxies.g.cs' does not exist (any more).
2025-03-11T10:41:28: File '/_/artifacts/obj/DependabotHelper/release/RazorSlices.SourceGenerator/RazorSlices.SourceGenerator.RazorSliceProxyGenerator/MartinCostello.DependabotHelper.RazorSliceProxies.g.cs' does not exist (any more).
```
