### PR TITLE
Disable CLSCompliant for tests

### DIFF
--- a/src/BuildKit/build/Testing.props
+++ b/src/BuildKit/build/Testing.props
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project>
+  <!-- -->
+  <PropertyGroup>
+    <AssemblyIsCLSCompliant>false</AssemblyIsCLSCompliant>
+  </PropertyGroup>
   <!-- Disable code coverage when building and running tests in Visual Studio -->
   <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' == 'true' ">
     <CollectCoverage>false</CollectCoverage>


### PR DESCRIPTION
Tests don't need to be `[CLSCompliant(true)]`.
