### PR TITLE
Fix typos

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseDefaultAssemblyOriginatorKeyFile>true</UseDefaultAssemblyOriginatorKeyFile>
     <UseDefaultCodeAnalysisRuleSet>true</UseDefaultCodeAnalysisRuleSet>
-    <VersionPrefix>0.2.2</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition="false">
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It is recommended to set these values in `Directory.Build.props` (or the `.cspro
 | `CoverageOutput` | `artifacts/coverage/{project}/coverage.xml` | The coverage output file to use with Microsoft.Testing.Platform |
 | `CoverageOutputPath` | `artifacts/coverage` | The path to write code coverage results to |
 | `CoverageRunSettings` | - | The path to the `.runsettings` file to use with Microsoft.Testing.Platform |
-| `GenerateGitMetadata` | `true` | Whether to embed additional `[AssemblyMetdata]` for Git projects |
+| `GenerateGitMetadata` | `true` | Whether to embed additional `[AssemblyMetadata]` for Git projects |
 | `TestResultsDirectory` | `artifacts/tests` | The path to write test logs to with Microsoft.Testing.Platform |
 | `UseDefaultAssemblyOriginatorKeyFile` | `false` | Whether to use the built-in `.snk` file |
 | `UseDefaultCodeAnalysisRuleSet` | `false` | Whether to use the built-in `.ruleset` file |
@@ -106,7 +106,7 @@ The following custom targets are provided:
 
 | **Target** | **Description** |
 |------------|-----------------|
-| `AddGitMetadaAssemblyAttributes` | Embeds additional `[AssemblyMetdata]` into assemblies with Git information |
+| `AddGitMetadataAssemblyAttributes` | Embeds additional `[AssemblyMetadata]` into assemblies with Git information |
 | `CheckCodeCoverageThreshold` | Checks the code coverage of a project meets a specified line and/or branch threshold when using Microsoft.Testing.Platform |
 | `GenerateCoverageReports` | Generates code coverage reports using ReportGenerator |
 | `SetGitHubContainerOutputs` | Writes a published container's digest, image and tag to `GITHUB_OUTPUT` |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The following custom targets are provided:
 
 | **Target** | **Description** |
 |------------|-----------------|
-| `AddGitMetadataAssemblyAttributes` | Embeds additional `[AssemblyMetadata]` into assemblies with Git information |
+| `AddGitHubMetadataAssemblyAttributes` | Embeds additional `[AssemblyMetadata]` into assemblies with Git and GitHub information |
 | `CheckCodeCoverageThreshold` | Checks the code coverage of a project meets a specified line and/or branch threshold when using Microsoft.Testing.Platform |
 | `GenerateCoverageReports` | Generates code coverage reports using ReportGenerator |
 | `SetGitHubContainerOutputs` | Writes a published container's digest, image and tag to `GITHUB_OUTPUT` |

--- a/src/BuildKit/build/Build.targets
+++ b/src/BuildKit/build/Build.targets
@@ -5,8 +5,8 @@
     <Using Include="System.Globalization" />
     <Using Include="System.Text" />
   </ItemGroup>
-  <!-- Embed additional Git metadata into the assembly -->
-  <Target Name="AddGitMetadataAssemblyAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(GenerateGitMetadata)' == 'true' ">
+  <!-- Embed additional Git/GitHub metadata into the assembly -->
+  <Target Name="AddGitHubMetadataAssemblyAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(GenerateGitMetadata)' == 'true' ">
     <PropertyGroup>
       <BuildId>$([MSBuild]::ValueOrDefault('$(BuildId)', '$(GITHUB_RUN_ID)'))</BuildId>
       <CommitBranch>$([MSBuild]::ValueOrDefault('$(CommitBranch)', '$(GITHUB_REF_NAME)'))</CommitBranch>

--- a/src/BuildKit/build/Build.targets
+++ b/src/BuildKit/build/Build.targets
@@ -6,7 +6,7 @@
     <Using Include="System.Text" />
   </ItemGroup>
   <!-- Embed additional Git metadata into the assembly -->
-  <Target Name="AddGitMetadaAssemblyAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(GenerateGitMetadata)' == 'true' ">
+  <Target Name="AddGitMetadataAssemblyAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(GenerateGitMetadata)' == 'true' ">
     <PropertyGroup>
       <BuildId>$([MSBuild]::ValueOrDefault('$(BuildId)', '$(GITHUB_RUN_ID)'))</BuildId>
       <CommitBranch>$([MSBuild]::ValueOrDefault('$(CommitBranch)', '$(GITHUB_REF_NAME)'))</CommitBranch>


### PR DESCRIPTION
- Fix typos in documentation.
- Fix typo in target name.
- Bump version to 0.3.0 for target rename and property renames from #28.
