### PR TITLE
Only include runsettings with MTP

### DIFF
--- a/src/BuildKit/build/Testing.props
+++ b/src/BuildKit/build/Testing.props
@@ -23,7 +23,7 @@
   <PropertyGroup Condition=" '$(CoverageRunSettings)' == '' AND '$(UseDefaultTestRunSettings)' == 'true' ">
     <CoverageRunSettings>$(MartinCostelloBuildKitRunSettings)</CoverageRunSettings>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(UseDefaultTestRunSettings)' == 'true' AND '$(CoverageRunSettings)' == '$(MartinCostelloBuildKitRunSettings)' ">
+  <ItemGroup Condition=" '$(UseMicrosoftTestingPlatformRunner)' == 'true' AND '$(UseDefaultTestRunSettings)' == 'true' AND '$(CoverageRunSettings)' == '$(MartinCostelloBuildKitRunSettings)' ">
     <AdditionalFiles Include="$(CoverageRunSettings)" Link="$(_CoverageRunSettingsFileName)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Only include the default `.runsettings` file in the project's additional items if `UseMicrosoftTestingPlatformRunner=true`.
