### PR TITLE
Ignore NU5104 for dotnet-vnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following custom targets are provided:
 | `AddGitHubMetadataAssemblyAttributes` | Embeds additional `[AssemblyMetadata]` into assemblies with Git and GitHub information |
 | `CheckCodeCoverageThreshold` | Checks the code coverage of a project meets a specified line and/or branch threshold when using Microsoft.Testing.Platform |
 | `GenerateCoverageReports` | Generates code coverage reports using ReportGenerator |
+| `RestoreNpmPackages` | Runs `npm install`/`npm ci` if `node_modules` does not exist when a `package.json` file is found in a project |
 | `SetGitHubContainerOutputs` | Writes a published container's digest, image and tag to `GITHUB_OUTPUT` |
 | `SetNuGetPackageOutputs` | Writes the comma-separated names and version of any published NuGet packages to `GITHUB_OUTPUT` |
 

--- a/samples/NuGetPackage/NuGetPackage.csproj
+++ b/samples/NuGetPackage/NuGetPackage.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <RootNamespace>MartinCostello.BuildKit.NuGetPackage</RootNamespace>
     <TargetFrameworks>net9.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>

--- a/src/BuildKit/build/Packages.props
+++ b/src/BuildKit/build/Packages.props
@@ -29,4 +29,19 @@
     <PackageReleaseNotes Condition=" '$(GitHubTag)' == '' ">$([MSBuild]::ValueOrDefault('$(PackageReleaseNotes)', 'See $(PackageProjectUrl)/releases for details.'))</PackageReleaseNotes>
     <PackageReleaseNotes Condition=" '$(GitHubTag)' != '' ">$([MSBuild]::ValueOrDefault('$(PackageReleaseNotes)', 'See $(PackageProjectUrl)/releases/tag/$(GitHubTag) for details.'))</PackageReleaseNotes>
   </PropertyGroup>
+  <!-- Ignore NuGet warnings about using preview packages for the dotnet-vnext branch -->
+  <PropertyGroup>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_TryIgnoreNuGetPreviewPackageWarnings</GenerateNuspecDependsOn>
+  </PropertyGroup>
+  <Target Name="_TryIgnoreNuGetPreviewPackageWarnings" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <_GitBranch>$([MSBuild]::ValueOrDefault('$(GITHUB_HEAD_REF)', '$(GITHUB_REF_NAME)'))</_GitBranch>
+    </PropertyGroup>
+    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(_GitBranch)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitBranch" />
+    </Exec>
+    <CreateProperty Value="$(NoWarn);NU5104" Condition=" '$(_GitBranch)' == 'dotnet-vnext' ">
+      <Output TaskParameter="Value" PropertyName="NoWarn" />
+    </CreateProperty>
+  </Target>
 </Project>

--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -76,7 +76,7 @@
     </Task>
   </UsingTask>
   <!-- Create properties for Coverlet from custom Items -->
-  <Target Name="CreateCoverletProperties" BeforeTargets="InstrumentModules" Condition=" '$(CollectCoverage)' == 'true' ">
+  <Target Name="_CreateCoverletProperties" BeforeTargets="InstrumentModules" Condition=" '$(CollectCoverage)' == 'true' ">
     <CreateProperty Value="@(CoverletExclude->'%(Identity)', ',')">
       <Output TaskParameter="Value" PropertyName="Exclude" />
     </CreateProperty>
@@ -94,7 +94,7 @@
     </CreateProperty>
   </Target>
   <!-- Update properties for Microsoft.Testing.Platform from custom properties -->
-  <Target Name="UpdateTestPlatformProperties" BeforeTargets="InvokeTestingPlatform">
+  <Target Name="_UpdateTestPlatformProperties" BeforeTargets="InvokeTestingPlatform">
     <!-- Override the TestResults directory for Microsoft.Testing.Platform -->
     <PropertyGroup>
       <TestResultsDirectory>$([MSBuild]::ValueOrDefault('$(TestResultsDirectory)', '$([System.IO.Path]::Combine($(ArtifactsPath), 'tests'))'))</TestResultsDirectory>
@@ -141,11 +141,11 @@
     <WriteLinesToFileWithRetry Condition=" '$(_ReportGeneratorOutputMarkdown)' == 'true' AND Exists('$(_CoverageGitHubSummary)') " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
   </Target>
   <!-- Clean coverage reports for dotnet clean -->
-  <Target Name="CleanCoverageReports">
+  <Target Name="_CleanCoverageReports">
     <RemoveDir Condition="Exists('$(CoverageOutputPath)')" Directories="$(CoverageOutputPath)" />
   </Target>
   <PropertyGroup>
-    <CleanDependsOn>$(CleanDependsOn);CleanCoverageReports</CleanDependsOn>
+    <CleanDependsOn>$(CleanDependsOn);_CleanCoverageReports</CleanDependsOn>
   </PropertyGroup>
   <!-- Workaround for https://github.com/microsoft/codecoverage/issues/160 -->
   <Target Name="CheckCodeCoverageThreshold" AfterTargets="GenerateCoverageReports" Condition=" '$(CollectCoverage)' == 'true' AND Exists('$(CoverageOutput)') AND '$(Threshold)' != '' ">


### PR DESCRIPTION
- Ignore the `NU5104` warning when building the `dotnet-vnext` branch.
- Update some targets to be `_`-prefixed to indicate they are private.
- Add `RestoreNpmPackages` to the documented targets.