### PR TITLE
Customisations for .NET nightly builds

### DIFF
--- a/src/BuildKit/build/Containers.targets
+++ b/src/BuildKit/build/Containers.targets
@@ -55,4 +55,16 @@
       <ContainerEnvironmentVariables Include="SSL_CERT_FILE" Value="$(ContainerWorkingDirectory)$(_PyroscopeCertificateBundleFile)" />
     </ItemGroup>
   </Target>
+  <!-- Use the nightly registry for the dotnet-nightly branch -->
+  <Target Name="_ConfigureContainerBaseImageForNightly" BeforeTargets="ComputeContainerBaseImage">
+    <PropertyGroup>
+      <_GitBranch>$([MSBuild]::ValueOrDefault('$(GITHUB_HEAD_REF)', '$(GITHUB_REF_NAME)'))</_GitBranch>
+    </PropertyGroup>
+    <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(_GitBranch)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitBranch" />
+    </Exec>
+    <CreateProperty Value="mcr.microsoft.com/dotnet/nightly/runtime-deps:$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))-preview-$(ContainerFamily)" Condition=" '$(ContainerBaseImage)' == '' AND '$(ContainerFamily)' != '' AND '$(_GitBranch)' == 'dotnet-nightly' ">
+      <Output TaskParameter="Value" PropertyName="ContainerBaseImage" />
+    </CreateProperty>
+  </Target>
 </Project>

--- a/src/BuildKit/build/Packages.props
+++ b/src/BuildKit/build/Packages.props
@@ -33,7 +33,7 @@
     <PackageReleaseNotes Condition=" '$(GitHubTag)' == '' ">$([MSBuild]::ValueOrDefault('$(PackageReleaseNotes)', 'See $(PackageProjectUrl)/releases for details.'))</PackageReleaseNotes>
     <PackageReleaseNotes Condition=" '$(GitHubTag)' != '' ">$([MSBuild]::ValueOrDefault('$(PackageReleaseNotes)', 'See $(PackageProjectUrl)/releases/tag/$(GitHubTag) for details.'))</PackageReleaseNotes>
   </PropertyGroup>
-  <!-- Ignore NuGet warnings about using preview packages for the dotnet-vnext branch -->
+  <!-- Ignore NuGet warnings about using preview packages for the dotnet-vnext and dotnet-nightly branches -->
   <PropertyGroup>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);_TryIgnoreNuGetPreviewPackageWarnings</GenerateNuspecDependsOn>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(_GitBranch)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="_GitBranch" />
     </Exec>
-    <CreateProperty Value="$(NoWarn);NU5104" Condition=" '$(_GitBranch)' == 'dotnet-vnext' ">
+    <CreateProperty Value="$(NoWarn);NU5104" Condition=" ('$(_GitBranch)' == 'dotnet-vnext') OR ('$(_GitBranch)' == 'dotnet-nightly') ">
       <Output TaskParameter="Value" PropertyName="NoWarn" />
     </CreateProperty>
   </Target>


### PR DESCRIPTION
- Also suppress `NU5104` in the `dotnet-nightly` branch.
- Configure the `ContainerBaseImage` to use the nightly feed when building containers for the `dotnet-nightly` branch.
