### PR TITLE
Update ContainerBaseImage

### DIFF
--- a/src/BuildKit/build/Containers.targets
+++ b/src/BuildKit/build/Containers.targets
@@ -63,7 +63,7 @@
     <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(_GitBranch)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="_GitBranch" />
     </Exec>
-    <CreateProperty Value="mcr.microsoft.com/dotnet/nightly/runtime-deps:$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))-preview-$(ContainerFamily)" Condition=" '$(ContainerBaseImage)' == '' AND '$(ContainerFamily)' != '' AND '$(_GitBranch)' == 'dotnet-nightly' ">
+    <CreateProperty Value="mcr.microsoft.com/dotnet/nightly/runtime-deps:$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))-preview-$(ContainerFamily)" Condition=" '$(ContainerBaseImage)' == '' AND '$(ContainerFamily)' != '' AND ('$(_GitBranch)' == 'dotnet-nightly' OR '$(GITHUB_BASE_REF)' == 'dotnet-nightly') ">
       <Output TaskParameter="Value" PropertyName="ContainerBaseImage" />
     </CreateProperty>
   </Target>


### PR DESCRIPTION
Also set `ContainerBaseImage` if the current branch is for a pull request targeting the `dotnet-nightly` branch.
