### PR TITLE
Update Sentry defaults

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <UseDefaultAssemblyOriginatorKeyFile>true</UseDefaultAssemblyOriginatorKeyFile>
     <UseDefaultCodeAnalysisRuleSet>true</UseDefaultCodeAnalysisRuleSet>
-    <VersionPrefix>0.5.5</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition="false">
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ It is recommended to set these values in `Directory.Build.props` (or the `.cspro
 | `UseDefaultCodeAnalysisRuleSet` | `false` | Whether to use the built-in `.ruleset` file |
 | `UseDefaultTestRunSettings` | `true` | Whether to use the built-in `.runsettings` file with Microsoft.Testing.Platform |
 | `UsePyroscope` | `false` | Whether to enable Pyroscope for container applications |
+| `UseSentry` | `true` | Whether to enable Sentry for container applications during publishing (requires `SentryAuthToken` to be specified) |
 
 The following properties are made available for use in the build process:
 
@@ -80,6 +81,8 @@ The following properties are made available for use in the build process:
 | `DynamicProxyGenAssembly2StrongNamePublicKey` | The public key to use with `[InternalsVisibleTo]` for DynamicProxyGenAssembly2 when using NSubstitute or Moq |
 | `GitHubBranchName` | The name of the current Git branch when not a pull request |
 | `GitHubPullRequest` | The number of the pull request that triggered the current build, if any |
+| `GitHubRepositoryName` | The name of the GitHub repository |
+| `GitHubRepositoryOwner` | The owner of the GitHub repository |
 | `GitHubRepositoryUrl` | The URL of the GitHub repository |
 | `GitHubTag` | The value of the tag that triggered the current build, if any |
 | `IsGitHubActions` | Set to `true` when running in GitHub Actions |

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -2,5 +2,6 @@ costello
 csproj
 dependabot
 msbuild
+octocat
 stderr
 stdout

--- a/src/BuildKit/build/GitHubActions.props
+++ b/src/BuildKit/build/GitHubActions.props
@@ -16,6 +16,8 @@
     <GitHubBranchName Condition=" '$(IsGitHubPullRequest)' == 'false' ">$(GITHUB_REF_NAME)</GitHubBranchName>
     <GitHubPullRequest Condition=" '$(IsGitHubPullRequest)' == 'true' ">$(GITHUB_REF_NAME.Replace('/merge', ''))</GitHubPullRequest>
     <GitHubTag Condition=" '$(IsGitHubTag)' == 'true' ">$(GITHUB_REF.Replace('refs/tags/', ''))</GitHubTag>
+    <GitHubRepositoryOwner>$(GITHUB_REPOSITORY_OWNER)</GitHubRepositoryOwner>
+    <GitHubRepositoryName>$(GITHUB_REPOSITORY.Replace('$(GitHubRepositoryOwner)/', ''))</GitHubRepositoryName>
     <GitHubRepositoryUrl>$(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY)</GitHubRepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/BuildKit/build/Sentry.props
+++ b/src/BuildKit/build/Sentry.props
@@ -4,12 +4,13 @@
   Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 -->
 <Project>
-  <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' AND '$(SentryProject)' != '' AND '$(SentryAuthToken)' != '' AND '$(ContainerRegistry)' != '' ">
+  <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' AND '$(SentryAuthToken)' != '' AND '$(ContainerRegistry)' != '' ">
     <UseSentry>$([MSBuild]::ValueOrDefault('$(UseSentry)', 'true'))</UseSentry>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UseSentry)' == 'true' ">
     <SentryCreateRelease>$([MSBuild]::ValueOrDefault('$(SentryCreateRelease)', 'true'))</SentryCreateRelease>
-    <SentryOrg>$([MSBuild]::ValueOrDefault('$(SentryOrg)', 'martincostello'))</SentryOrg>
+    <SentryOrg>$([MSBuild]::ValueOrDefault('$(SentryOrg)', '$(GitHubRepositoryOwner)'))</SentryOrg>
+    <SentryProject>$([MSBuild]::ValueOrDefault('$(SentryProject)', '$(GitHubRepositoryName)'))</SentryProject>
     <SentrySetCommits>$([MSBuild]::ValueOrDefault('$(SentrySetCommits)', 'true'))</SentrySetCommits>
     <SentryUploadSymbols>$([MSBuild]::ValueOrDefault('$(SentryUploadSymbols)', 'true'))</SentryUploadSymbols>
   </PropertyGroup>

--- a/src/BuildKit/build/Sentry.props
+++ b/src/BuildKit/build/Sentry.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UseSentry)' == 'true' ">
     <SentryCreateRelease>$([MSBuild]::ValueOrDefault('$(SentryCreateRelease)', 'true'))</SentryCreateRelease>
-    <SentryOrg>$([MSBuild]::ValueOrDefault('$(SentryOrg)', 'martin-costello'))</SentryOrg>
+    <SentryOrg>$([MSBuild]::ValueOrDefault('$(SentryOrg)', 'martincostello'))</SentryOrg>
     <SentrySetCommits>$([MSBuild]::ValueOrDefault('$(SentrySetCommits)', 'true'))</SentrySetCommits>
     <SentryUploadSymbols>$([MSBuild]::ValueOrDefault('$(SentryUploadSymbols)', 'true'))</SentryUploadSymbols>
   </PropertyGroup>

--- a/tests/BuildKit.Tests/SentryTests.cs
+++ b/tests/BuildKit.Tests/SentryTests.cs
@@ -64,7 +64,7 @@ public class SentryTests(ITestOutputHelper outputHelper)
         actual.ShouldNotBeNull();
         actual.ShouldContainKeyAndValue("UseSentry", "true");
         actual.ShouldContainKeyAndValue("SentryCreateRelease", "true");
-        actual.ShouldContainKeyAndValue("SentryOrg", "martin-costello");
+        actual.ShouldContainKeyAndValue("SentryOrg", "martincostello");
         actual.ShouldContainKeyAndValue("SentrySetCommits", "true");
         actual.ShouldContainKeyAndValue("SentryUploadSymbols", "true");
     }

--- a/tests/BuildKit.Tests/SentryTests.cs
+++ b/tests/BuildKit.Tests/SentryTests.cs
@@ -10,6 +10,7 @@ public class SentryTests(ITestOutputHelper outputHelper)
     [
         "SentryCreateRelease",
         "SentryOrg",
+        "SentryProject",
         "SentrySetCommits",
         "SentryUploadSymbols",
         "UseSentry",
@@ -23,6 +24,8 @@ public class SentryTests(ITestOutputHelper outputHelper)
         {
             ["ContainerRegistry"] = string.Empty,
             ["GITHUB_ACTIONS"] = "false",
+            ["GITHUB_REPOSITORY"] = string.Empty,
+            ["GITHUB_REPOSITORY_OWNER"] = string.Empty,
             ["SentryAuthToken"] = string.Empty,
             ["SentryProject"] = string.Empty,
         };
@@ -38,6 +41,7 @@ public class SentryTests(ITestOutputHelper outputHelper)
         actual.ShouldContainKeyAndValue("UseSentry", string.Empty);
         actual.ShouldContainKeyAndValue("SentryCreateRelease", string.Empty);
         actual.ShouldContainKeyAndValue("SentryOrg", string.Empty);
+        actual.ShouldContainKeyAndValue("SentryProject", string.Empty);
         actual.ShouldContainKeyAndValue("SentrySetCommits", string.Empty);
         actual.ShouldContainKeyAndValue("SentryUploadSymbols", string.Empty);
     }
@@ -50,8 +54,9 @@ public class SentryTests(ITestOutputHelper outputHelper)
         {
             ["ContainerRegistry"] = "containers.acr.io",
             ["GITHUB_ACTIONS"] = "true",
+            ["GITHUB_REPOSITORY"] = "octocat/Hello-World",
+            ["GITHUB_REPOSITORY_OWNER"] = "octocat",
             ["SentryAuthToken"] = "not-a-secret",
-            ["SentryProject"] = "my-project",
         };
 
         // Act
@@ -64,7 +69,8 @@ public class SentryTests(ITestOutputHelper outputHelper)
         actual.ShouldNotBeNull();
         actual.ShouldContainKeyAndValue("UseSentry", "true");
         actual.ShouldContainKeyAndValue("SentryCreateRelease", "true");
-        actual.ShouldContainKeyAndValue("SentryOrg", "martincostello");
+        actual.ShouldContainKeyAndValue("SentryOrg", "octocat");
+        actual.ShouldContainKeyAndValue("SentryProject", "Hello-World");
         actual.ShouldContainKeyAndValue("SentrySetCommits", "true");
         actual.ShouldContainKeyAndValue("SentryUploadSymbols", "true");
     }


### PR DESCRIPTION
- Compute the Sentry organisation and project from the GitHub repository name.
- Add `GitHubRepositoryOwner` and `GitHubRepositoryName` convenience MSBuild properties.
