### PR TITLE
Do not use Sentry in PRs

### DIFF
--- a/src/BuildKit/build/Sentry.props
+++ b/src/BuildKit/build/Sentry.props
@@ -4,7 +4,7 @@
   Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 -->
 <Project>
-  <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' AND '$(SentryAuthToken)' != '' AND '$(ContainerRegistry)' != '' ">
+  <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' AND '$(IsGitHubPullRequest)' != 'true' AND '$(SentryAuthToken)' != '' AND '$(ContainerRegistry)' != '' ">
     <UseSentry>$([MSBuild]::ValueOrDefault('$(UseSentry)', 'true'))</UseSentry>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UseSentry)' == 'true' ">

--- a/tests/BuildKit.Tests/SentryTests.cs
+++ b/tests/BuildKit.Tests/SentryTests.cs
@@ -24,6 +24,7 @@ public class SentryTests(ITestOutputHelper outputHelper)
         {
             ["ContainerRegistry"] = string.Empty,
             ["GITHUB_ACTIONS"] = "false",
+            ["GITHUB_HEAD_REF"] = string.Empty,
             ["GITHUB_REPOSITORY"] = string.Empty,
             ["GITHUB_REPOSITORY_OWNER"] = string.Empty,
             ["SentryAuthToken"] = string.Empty,
@@ -54,6 +55,7 @@ public class SentryTests(ITestOutputHelper outputHelper)
         {
             ["ContainerRegistry"] = "containers.acr.io",
             ["GITHUB_ACTIONS"] = "true",
+            ["GITHUB_HEAD_REF"] = string.Empty,
             ["GITHUB_REPOSITORY"] = "octocat/Hello-World",
             ["GITHUB_REPOSITORY_OWNER"] = "octocat",
             ["SentryAuthToken"] = "not-a-secret",


### PR DESCRIPTION
Disable Sentry when publishing from pull requests. Otherwise, any new issues get associated with the PR build instead of the build from the default branch post-merge.
