### PR TITLE
Finalize Sentry releases

### DIFF
--- a/src/BuildKit/build/Sentry.props
+++ b/src/BuildKit/build/Sentry.props
@@ -11,6 +11,7 @@
     <SentryCreateRelease>$([MSBuild]::ValueOrDefault('$(SentryCreateRelease)', 'true'))</SentryCreateRelease>
     <SentryOrg>$([MSBuild]::ValueOrDefault('$(SentryOrg)', '$(GitHubRepositoryOwner)'))</SentryOrg>
     <SentryProject>$([MSBuild]::ValueOrDefault('$(SentryProject)', '$(GitHubRepositoryName)'))</SentryProject>
+    <SentryReleaseOptions>$([MSBuild]::ValueOrDefault('$(SentryReleaseOptions)', '--finalize'))</SentryReleaseOptions>
     <SentrySetCommits>$([MSBuild]::ValueOrDefault('$(SentrySetCommits)', 'true'))</SentrySetCommits>
     <SentryUploadSymbols>$([MSBuild]::ValueOrDefault('$(SentryUploadSymbols)', 'true'))</SentryUploadSymbols>
   </PropertyGroup>


### PR DESCRIPTION
- Reverts martincostello/build-kit#75.
- Depends on https://github.com/getsentry/sentry-dotnet/pull/4109.
