### PR TITLE
Disable Sentry native with AoT

### DIFF
--- a/src/BuildKit/build/Sentry.props
+++ b/src/BuildKit/build/Sentry.props
@@ -14,4 +14,8 @@
     <SentrySetCommits>$([MSBuild]::ValueOrDefault('$(SentrySetCommits)', 'true'))</SentrySetCommits>
     <SentryUploadSymbols>$([MSBuild]::ValueOrDefault('$(SentryUploadSymbols)', 'true'))</SentryUploadSymbols>
   </PropertyGroup>
+  <!-- HACK Workaround for https://github.com/getsentry/sentry-dotnet/issues/4116 -->
+  <PropertyGroup Condition=" '$(UseSentry)' == 'true' AND '$(PublishAot)' == 'true' AND $([System.OperatingSystem]::IsLinux()) ">
+    <SentryNative>false</SentryNative>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Disable Sentry native when native AoT publishing is enabled on Linux.
