### PR TITLE
Use SuppressDependenciesWhenPacking

### DIFF
--- a/src/BuildKit/MartinCostello.BuildKit.csproj
+++ b/src/BuildKit/MartinCostello.BuildKit.csproj
@@ -7,6 +7,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <OutputType>Library</OutputType>
     <PackageId>MartinCostello.BuildKit</PackageId>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Title>MartinCostello.BuildKit</Title>
   </PropertyGroup>


### PR DESCRIPTION
This removes the `dependencies` section of the nuspec, so then the package doesn't depend on `.NETStandard 2.0`