### PR TITLE
Fix StabilizeVersion

### DIFF
--- a/src/BuildKit/build/Version.props
+++ b/src/BuildKit/build/Version.props
@@ -8,18 +8,4 @@
   <PropertyGroup>
     <VersionPrefix>$([MSBuild]::ValueOrDefault('$(VersionPrefix)', '1.0.0'))</VersionPrefix>
   </PropertyGroup>
-  <!--
-    Apply default incremental versioning when building in GitHub Actions. For example:
-    - {Tag} for building a tag
-    - 1.0.0-beta.{Workflow run number} for building a branch
-    - 1.0.0-pr.{PR number}.{Workflow run number} for building a pull request
-    - 1.0.0 when publishing a container image for a branch
-  -->
-  <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' ">
-    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GitHubPullRequest)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
-    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GitHubPullRequest)' != '' ">pr.$(GitHubPullRequest).$(GITHUB_RUN_NUMBER)</VersionSuffix>
-    <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' ">$(GitHubTag.TrimStart('v'))</VersionPrefix>
-    <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
-    <FileVersion>$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
-  </PropertyGroup>
 </Project>

--- a/src/BuildKit/build/Version.targets
+++ b/src/BuildKit/build/Version.targets
@@ -4,6 +4,20 @@
   Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 -->
 <Project>
+  <!--
+    Apply default incremental versioning when building in GitHub Actions. For example:
+    - {Tag} for building a tag
+    - 1.0.0-beta.{Workflow run number} for building a branch
+    - 1.0.0-pr.{PR number}.{Workflow run number} for building a pull request
+    - 1.0.0 when publishing a container image for a branch
+  -->
+  <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' ">
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GitHubPullRequest)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GitHubPullRequest)' != '' ">pr.$(GitHubPullRequest).$(GITHUB_RUN_NUMBER)</VersionSuffix>
+    <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' ">$(GitHubTag.TrimStart('v'))</VersionPrefix>
+    <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
+    <FileVersion>$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
+  </PropertyGroup>
   <PropertyGroup>
     <StabilizeVersion>$([MSBuild]::ValueOrDefault('$(StabilizeVersion)', 'false'))</StabilizeVersion>
   </PropertyGroup>

--- a/tests/BuildKit.Tests/IntegrationTests.cs
+++ b/tests/BuildKit.Tests/IntegrationTests.cs
@@ -69,7 +69,7 @@ public abstract class IntegrationTests(ITestOutputHelper outputHelper)
         using var msbuild = Process.Start(startInfo);
         msbuild.ShouldNotBeNull();
 
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
 
         await msbuild.WaitForExitAsync(linked.Token);

--- a/tests/BuildKit.Tests/VersionTests.cs
+++ b/tests/BuildKit.Tests/VersionTests.cs
@@ -8,6 +8,7 @@ public class VersionTests(ITestOutputHelper outputHelper)
 {
     private static readonly string[] PropertyNames =
     [
+        "FileVersion",
         "VersionPrefix",
         "VersionSuffix",
     ];
@@ -18,6 +19,7 @@ public class VersionTests(ITestOutputHelper outputHelper)
         // Arrange
         var properties = new Dictionary<string, string?>()
         {
+            ["GITHUB_ACTIONS"] = "true",
             ["StabilizeVersion"] = "true",
         };
 
@@ -29,8 +31,41 @@ public class VersionTests(ITestOutputHelper outputHelper)
 
         // Assert
         actual.ShouldNotBeNull();
+        actual.ShouldContainKey("FileVersion");
         actual.ShouldContainKey("VersionPrefix");
         actual.ShouldContainKeyAndValue("VersionSuffix", string.Empty);
+        actual["FileVersion"].ShouldNotBeNullOrWhiteSpace();
         actual["VersionPrefix"].ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task StabilizeVersion_Does_Not_Set_VersionSuffix_In_GitHub_Actions()
+    {
+        // Arrange
+        var properties = new Dictionary<string, string?>()
+        {
+            ["GITHUB_ACTIONS"] = "true",
+            ["GITHUB_BASE_REF"] = string.Empty,
+            ["GITHUB_HEAD_REF"] = string.Empty,
+            ["GITHUB_REF"] = "refs/heads/main",
+            ["GITHUB_REF_NAME"] = "main",
+            ["GITHUB_SHA"] = "1234567890abcdef1234567890abcdef12345678",
+            ["GITHUB_REPOSITORY"] = "martincostello/buildkit",
+            ["GITHUB_RUN_NUMBER"] = "4",
+            ["StabilizeVersion"] = "true",
+            ["VersionPrefix"] = "1.2.3",
+        };
+
+        // Act
+        var actual = await EvaluateProperties(
+            PropertyNames,
+            properties,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldContainKeyAndValue("FileVersion", "1.2.3.4");
+        actual.ShouldContainKeyAndValue("VersionPrefix", "1.2.3");
+        actual.ShouldContainKeyAndValue("VersionSuffix", string.Empty);
     }
 }


### PR DESCRIPTION
Move evaluation to targets so that `StabilizeVersion` has an effect at the right time.
