### PR TITLE
Disable NETSDK1057

### DIFF
--- a/src/BuildKit/build/Analyzers.props
+++ b/src/BuildKit/build/Analyzers.props
@@ -37,4 +37,8 @@
   <ItemGroup Condition="Exists('$(_StyleCopSettings)')">
     <AdditionalFiles Include="$(_StyleCopSettings)" Link="stylecop.json" />
   </ItemGroup>
+  <!-- Disable warnings about .NET SDK preview versions -->
+  <PropertyGroup>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Disable the `NETSDK1057` warning message when using previews of the .NET SDK.
