### PR TITLE
Fix prerelease tags

### DIFF
--- a/src/BuildKit/build/Version.props
+++ b/src/BuildKit/build/Version.props
@@ -21,7 +21,7 @@
     <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' ">$(GitHubTag.TrimStart('v'))</VersionPrefix>
     <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' AND $(VersionPrefix.Contains('-')) ">$(VersionPrefix.Split('-')[1])</VersionSuffix>
     <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' AND $(VersionPrefix.Contains('-')) ">$(VersionPrefix.Split('-')[0])</VersionPrefix>
-    <VersionSuffix Condition=" ('$(IsGitHubTag)' == 'true' AND !$(VersionPrefix.Contains('-'))) OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
+    <VersionSuffix Condition=" ('$(IsGitHubTag)' == 'true' AND !$(GitHubTag.Contains('-'))) OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
     <FileVersion>$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(StabilizeVersion)' == 'true' ">

--- a/src/BuildKit/build/Version.props
+++ b/src/BuildKit/build/Version.props
@@ -21,7 +21,7 @@
     <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' ">$(GitHubTag.TrimStart('v'))</VersionPrefix>
     <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' AND $(VersionPrefix.Contains('-')) ">$(VersionPrefix.Split('-')[1])</VersionSuffix>
     <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' AND $(VersionPrefix.Contains('-')) ">$(VersionPrefix.Split('-')[0])</VersionPrefix>
-    <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
+    <VersionSuffix Condition=" ('$(IsGitHubTag)' == 'true' AND !$(VersionPrefix.Contains('-'))) OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
     <FileVersion>$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(StabilizeVersion)' == 'true' ">

--- a/src/BuildKit/build/Version.props
+++ b/src/BuildKit/build/Version.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <!--
     Apply default incremental versioning when building in GitHub Actions. For example:
-    - {Tag} for building a tag
+    - {Tag} for building a tag (with any prerelease suffix removed)
     - 1.0.0-beta.{Workflow run number} for building a branch
     - 1.0.0-pr.{PR number}.{Workflow run number} for building a pull request
     - 1.0.0 when publishing a container image for a branch
@@ -19,6 +19,8 @@
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GitHubPullRequest)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GitHubPullRequest)' != '' ">pr.$(GitHubPullRequest).$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' ">$(GitHubTag.TrimStart('v'))</VersionPrefix>
+    <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' AND $(VersionPrefix.Contains('-')) ">$(VersionPrefix.Split('-')[1])</VersionSuffix>
+    <VersionPrefix Condition=" '$(IsGitHubTag)' == 'true' AND $(VersionPrefix.Contains('-')) ">$(VersionPrefix.Split('-')[0])</VersionPrefix>
     <VersionSuffix Condition=" '$(IsGitHubTag)' == 'true' OR ('$(GitHubPullRequest)' == '' AND '$(PublishProfile)' == 'DefaultContainer') "></VersionSuffix>
     <FileVersion>$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
   </PropertyGroup>

--- a/tests/BuildKit.Tests/VersionTests.cs
+++ b/tests/BuildKit.Tests/VersionTests.cs
@@ -68,4 +68,62 @@ public class VersionTests(ITestOutputHelper outputHelper)
         actual.ShouldContainKeyAndValue("VersionPrefix", "1.2.3");
         actual.ShouldContainKeyAndValue("VersionSuffix", string.Empty);
     }
+
+    [Fact]
+    public async Task StabilizeVersion_Sets_Correct_Version_For_Preview_In_GitHub_Actions()
+    {
+        // Arrange
+        var properties = new Dictionary<string, string?>()
+        {
+            ["GITHUB_ACTIONS"] = "true",
+            ["GITHUB_BASE_REF"] = string.Empty,
+            ["GITHUB_HEAD_REF"] = string.Empty,
+            ["GITHUB_REF"] = "refs/tags/v1.2.3-preview.1",
+            ["GITHUB_REF_NAME"] = "v1.2.3-preview.1",
+            ["GITHUB_SHA"] = "1234567890abcdef1234567890abcdef12345678",
+            ["GITHUB_REPOSITORY"] = "martincostello/buildkit",
+            ["GITHUB_RUN_NUMBER"] = "4",
+        };
+
+        // Act
+        var actual = await EvaluateProperties(
+            PropertyNames,
+            properties,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldContainKeyAndValue("FileVersion", "1.2.3.4");
+        actual.ShouldContainKeyAndValue("VersionPrefix", "1.2.3");
+        actual.ShouldContainKeyAndValue("VersionSuffix", "preview.1");
+    }
+
+    [Fact]
+    public async Task StabilizeVersion_Sets_Correct_Version_For_Stable_In_GitHub_Actions()
+    {
+        // Arrange
+        var properties = new Dictionary<string, string?>()
+        {
+            ["GITHUB_ACTIONS"] = "true",
+            ["GITHUB_BASE_REF"] = string.Empty,
+            ["GITHUB_HEAD_REF"] = string.Empty,
+            ["GITHUB_REF"] = "refs/tags/v1.2.3",
+            ["GITHUB_REF_NAME"] = "v1.2.3",
+            ["GITHUB_SHA"] = "1234567890abcdef1234567890abcdef12345678",
+            ["GITHUB_REPOSITORY"] = "martincostello/buildkit",
+            ["GITHUB_RUN_NUMBER"] = "4",
+        };
+
+        // Act
+        var actual = await EvaluateProperties(
+            PropertyNames,
+            properties,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldContainKeyAndValue("FileVersion", "1.2.3.4");
+        actual.ShouldContainKeyAndValue("VersionPrefix", "1.2.3");
+        actual.ShouldContainKeyAndValue("VersionSuffix", string.Empty);
+    }
 }

--- a/tests/BuildKit.Tests/VersionTests.cs
+++ b/tests/BuildKit.Tests/VersionTests.cs
@@ -70,7 +70,7 @@ public class VersionTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task StabilizeVersion_Sets_Correct_Version_For_Preview_In_GitHub_Actions()
+    public async Task Sets_Correct_Versions_For_Preview_Tag_In_GitHub_Actions()
     {
         // Arrange
         var properties = new Dictionary<string, string?>()
@@ -99,7 +99,7 @@ public class VersionTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
-    public async Task StabilizeVersion_Sets_Correct_Version_For_Stable_In_GitHub_Actions()
+    public async Task Sets_Correct_Versions_For_Stable_Tag_In_GitHub_Actions()
     {
         // Arrange
         var properties = new Dictionary<string, string?>()


### PR DESCRIPTION
Fix incorrect `FileVersion` being generated for Git tags that are for prerelease versions.
