### PR TITLE
Enable CheckSdkVulnerabilities

### DIFF
--- a/src/BuildKit/build/Build.props
+++ b/src/BuildKit/build/Build.props
@@ -71,4 +71,8 @@
       <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
     </AssemblyAttribute>
   </ItemGroup>
+  <!-- Check the current .NET SDK is patched -->
+  <PropertyGroup>
+    <CheckSdkVulnerabilities>true</CheckSdkVulnerabilities>
+  </PropertyGroup>
 </Project>

--- a/src/BuildKit/build/Build.props
+++ b/src/BuildKit/build/Build.props
@@ -73,6 +73,6 @@
   </ItemGroup>
   <!-- Check the current .NET SDK is patched -->
   <PropertyGroup>
-    <CheckSdkVulnerabilities>true</CheckSdkVulnerabilities>
+    <CheckSdkVulnerabilities>$([MSBuild]::ValueOrDefault('$(CheckSdkVulnerabilities)', 'true'))</CheckSdkVulnerabilities>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Enable [`CheckSdkVulnerabilities`](https://jamiemagee.co.uk/blog/a-new-way-to-catch-a-vulnerable-dotnet-sdk/) ahead of .NET 11 preview.5.
