### PR TITLE
Refactor use of secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,6 @@ jobs:
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         flags: ${{ matrix.os-name }}
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
@@ -79,7 +78,6 @@ jobs:
       with:
         flags: ${{ matrix.os-name }}
         report_type: test_results
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Publish container
       id: publish-container
@@ -227,6 +225,14 @@ jobs:
       github.event.repository.fork == false &&
       startsWith(github.ref, 'refs/tags/v')
 
+    environment:
+      name: release
+      deployment: false
+
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
 
     - name: Download packages
@@ -258,7 +264,7 @@ jobs:
         ASSETS_PATH: ./dist
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
         gh api "/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" --jq ".[].raw_key" | gpg --import
@@ -272,10 +278,17 @@ jobs:
           gpg --verify "${fname}.sig" "${fname}"
         done
 
+    - name: Get GitHub token for release
+      id: get-release-token
+      # zizmor: ignore[ref-version-mismatch] False positive
+      uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+      with:
+        profile-name: release
+
     - name: Draft release
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
-        github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+        github-token: ${{ steps.get-release-token.outputs.token }}
         script: |
           const { repo, owner } = context.repo;
           const tag_name = process.env.GITHUB_REF_NAME;
@@ -296,6 +309,6 @@ jobs:
     - name: Attach files to the release
       shell: bash
       env:
-        GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+        GH_TOKEN: ${{ steps.get-release-token.outputs.token }}
       run: |
         gh release upload "${GITHUB_REF_NAME}" "dist/*" --clobber --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -16,12 +16,27 @@ permissions: {}
 jobs:
   bump-version:
     runs-on: [ ubuntu-24.04 ]
+    if: github.event.repository.fork == false
 
     concurrency:
       group: '${{ github.workflow }}-bump'
       cancel-in-progress: false
 
+    environment:
+      name: release
+      deployment: false
+
+    permissions:
+      id-token: write
+
     steps:
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,7 +44,7 @@ jobs:
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           ref: ${{ github.event.release.tag_name || github.event.repository.default_branch }}
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Bump version
         id: bump-version
@@ -151,7 +166,7 @@ jobs:
           HEAD_BRANCH: ${{ steps.push-changes.outputs.branch-name }}
           NEXT_VERSION: ${{ steps.push-changes.outputs.version }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const nextVersion = process.env.NEXT_VERSION;
             const { repo, owner } = context.repo;
@@ -210,6 +225,9 @@ jobs:
       group: '${{ github.workflow }}-milestone'
       cancel-in-progress: false
 
+    permissions:
+      issues: write
+
     steps:
 
       - name: Close milestone
@@ -218,7 +236,7 @@ jobs:
           RELEASE_DATE: ${{ github.event.release.published_at }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { repo, owner } = context.repo;
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,13 +39,14 @@ jobs:
 
     permissions:
       attestations: read
+      contents: read
       id-token: write
 
     steps:
 
     - name: Download files from release
       env:
-        GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release download "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}"
 
@@ -70,7 +71,7 @@ jobs:
     - name: Get .NET SDK version
       id: get-dotnet-sdk-version
       env:
-        GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         dotnet_sdk_version="$(gh api -H "Accept: application/vnd.github.v3.raw" "repos/${GITHUB_REPOSITORY}/contents/global.json?ref=${RELEASE_TAG}" | jq -r .sdk.version)"
         echo "dotnet-sdk-version=${dotnet_sdk_version}" >> "${GITHUB_OUTPUT}"
@@ -102,12 +103,19 @@ jobs:
       run: |
         dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}" && echo "::notice title=nuget.org::Published version ${PACKAGE_VERSION} to NuGet.org."
 
+    - name: Get GitHub token
+      id: get-github-token
+      # zizmor: ignore[ref-version-mismatch] False positive
+      uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+      with:
+        profile-name: publish
+
     - name: Publish nuget_packages_published
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
       with:
         event-type: nuget_packages_published
         repository: ${{ github.repository_owner }}/github-automation
-        token: ${{ secrets.COSTELLOBOT_TOKEN }}
+        token: ${{ steps.get-github-token.outputs.token }}
         client-payload: |-
           {
             "repository": "${{ github.repository }}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,27 @@ permissions: {}
 jobs:
   release:
     runs-on: [ ubuntu-24.04 ]
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: release
+      deployment: false
+
+    permissions:
+      id-token: write
+
     steps:
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,7 +48,7 @@ jobs:
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           ref: ${{ github.event.inputs.branch || github.event.repository.default_branch }}
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Get version
         id: get-version
@@ -89,4 +104,4 @@ jobs:
           VERSION: ${{ steps.get-version.outputs.version }}
         run: |
           TAG="v${VERSION}"
-          git tag "${TAG}" -m "Release ${TAG}" && git push origin "refs/tags/$TAG"
+          git tag "${TAG}" -m "Release ${TAG}" && git push origin "refs/tags/${TAG}"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
- Use GitHub token broker.
- Scope all secrets to environments.
- Remove codecov token.
