### PR TITLE
Add explicit permissions

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 5 * * MON'
   workflow_dispatch:
 
-permissions: read-all # zizmor: ignore[excessive-permissions] Recommended permissions for OSSF Scorecard
+permissions: {}
 
 jobs:
   analysis:
@@ -16,7 +16,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     permissions:
+      checks: read
+      contents: read
       id-token: write
+      issues: read
+      pull-requests: read
       security-events: write
 
     steps:


### PR DESCRIPTION
Add explicit permissions for OSSF Scorecard rather than `read-all`.
