### PR TITLE
Enable Code Flow Guard

### DIFF
--- a/src/BuildKit/build/Build.props
+++ b/src/BuildKit/build/Build.props
@@ -75,4 +75,8 @@
   <PropertyGroup>
     <CheckSdkVulnerabilities>$([MSBuild]::ValueOrDefault('$(CheckSdkVulnerabilities)', 'true'))</CheckSdkVulnerabilities>
   </PropertyGroup>
+  <!-- Enable Control Flow Guard -->
+  <PropertyGroup>
+    <ControlFlowGuard>$([MSBuild]::ValueOrDefault('$(ControlFlowGuard)', 'Guard'))</ControlFlowGuard>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Enable [Code Flow Guard](https://github.com/dotnet/docs/blob/6e874953574608b68c8b4523df8b7e2e9a517043/docs/core/deploying/native-aot/security.md#control-flow-guard) by default.
