### PR TITLE
Consume SOURCE_DATE_EPOCH

### DIFF
--- a/src/BuildKit/build/Build.targets
+++ b/src/BuildKit/build/Build.targets
@@ -24,7 +24,7 @@
       <BuildId>$([MSBuild]::ValueOrDefault('$(BuildId)', '$(GITHUB_RUN_ID)'))</BuildId>
       <CommitBranch>$([MSBuild]::ValueOrDefault('$(CommitBranch)', '$(GITHUB_REF_NAME)'))</CommitBranch>
       <CommitHash>$([MSBuild]::ValueOrDefault('$(CommitHash)', '$(GITHUB_SHA)'))</CommitHash>
-      <_BuildTimestamp>$([System.DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssK'))</_BuildTimestamp>
+      <_BuildTimestampEpoch>$([MSBuild]::ValueOrDefault('$(SOURCE_DATE_EPOCH)', ''))</_BuildTimestampEpoch>
     </PropertyGroup>
     <Exec Command="git rev-parse --abbrev-ref HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitBranch)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="CommitBranch" />
@@ -32,6 +32,16 @@
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitHash)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="CommitHash" />
     </Exec>
+    <PropertyGroup>
+    <_GitTimestampFormat Condition="$([System.OperatingSystem]::IsWindows())">%25%25ct</_GitTimestampFormat>
+    <_GitTimestampFormat Condition="!$([System.OperatingSystem]::IsWindows())">%25ct</_GitTimestampFormat>
+  </PropertyGroup>
+    <Exec Command="git log -1 --format=$(_GitTimestampFormat)" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(_BuildTimestampEpoch)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_BuildTimestampEpoch" />
+    </Exec>
+    <PropertyGroup>
+      <_BuildTimestamp>$([System.DateTimeOffset]::FromUnixTimeSeconds($(_BuildTimestampEpoch)).ToString("yyyy-MM-ddTHH:mm:ssK"))</_BuildTimestamp>
+    </PropertyGroup>
     <ItemGroup>
       <AssemblyMetadata Include="BuildId" Value="$(BuildId)" Condition=" $(BuildId) != '' " />
       <AssemblyMetadata Include="BuildTimestamp" Value="$(_BuildTimestamp)" />


### PR DESCRIPTION
Consume the value of `SOURCE_DATE_EPOCH` and use it for the value of the `BuildTimestamp` assembly metadata variable, if available.
