### PR TITLE
Use NUGET_API_KEY

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,11 +97,11 @@ jobs:
     - name: Push NuGet packages to NuGet.org
       shell: bash
       env:
-        API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         PACKAGE_VERSION: ${{ steps.get-packages.outputs.package-version }}
         SOURCE: https://api.nuget.org/v3/index.json
       run: |
-        dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}" && echo "::notice title=nuget.org::Published version ${PACKAGE_VERSION} to NuGet.org."
+        dotnet nuget push "*.nupkg" --skip-duplicate --source "${SOURCE}" && echo "::notice title=nuget.org::Published version ${PACKAGE_VERSION} to NuGet.org."
 
     - name: Get GitHub token
       id: get-github-token


### PR DESCRIPTION
Use the `NUGET_API_KEY` environment variable instead of specifying `--api-key`.
