### PR TITLE
Make coverage output TFM-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It is recommended to set these values in `Directory.Build.props` (or the `.cspro
 | ------------ | ----------------- | --------------- |
 | `AssemblyIsCLSCompliant` | `true` (`false` for test projects) | Emits the `[CLSCompliant]` attribute with the specified value |
 | `CoverageFormat` | `cobertura` | The coverage output format to use with Microsoft.Testing.Platform |
-| `CoverageOutput` | `artifacts/coverage/{project}/coverage.$(TargetFramework).xml` | The coverage output file to use with Microsoft.Testing.Platform |
+| `CoverageOutput` | `artifacts/coverage/{project}/coverage.{targetFramework}.xml` | The coverage output file to use with Microsoft.Testing.Platform |
 | `CoverageOutputPath` | `artifacts/coverage` | The path to write code coverage results to |
 | `CoverageRunSettings` | - | The path to the `.runsettings` file to use with Microsoft.Testing.Platform |
 | `GenerateGitMetadata` | `true` | Whether to embed additional `[AssemblyMetadata]` for Git projects |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It is recommended to set these values in `Directory.Build.props` (or the `.cspro
 | ------------ | ----------------- | --------------- |
 | `AssemblyIsCLSCompliant` | `true` (`false` for test projects) | Emits the `[CLSCompliant]` attribute with the specified value |
 | `CoverageFormat` | `cobertura` | The coverage output format to use with Microsoft.Testing.Platform |
-| `CoverageOutput` | `artifacts/coverage/{project}/coverage.xml` | The coverage output file to use with Microsoft.Testing.Platform |
+| `CoverageOutput` | `artifacts/coverage/{project}/coverage.$(TargetFramework).xml` | The coverage output file to use with Microsoft.Testing.Platform |
 | `CoverageOutputPath` | `artifacts/coverage` | The path to write code coverage results to |
 | `CoverageRunSettings` | - | The path to the `.runsettings` file to use with Microsoft.Testing.Platform |
 | `GenerateGitMetadata` | `true` | Whether to embed additional `[AssemblyMetadata]` for Git projects |

--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -140,8 +140,7 @@
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest;InvokeTestingPlatform" DependsOnTargets="$(GenerateCoverageReportsDependsOn)" Condition=" '$(CollectCoverage)' == 'true' ">
     <!-- Collect any coverage output XML files from both coverlet and Microsoft.Testing.Platform -->
     <ItemGroup>
-      <_CoverageReports Include="$(CoverageOutputPath)\**\coverage.xml" />
-      <_CoverageReports Include="$(CoverageOutputPath)\**\coverage.cobertura.xml" />
+      <_CoverageReports Include="$(CoverageOutputPath)\**\coverage*.xml" />
     </ItemGroup>
     <PropertyGroup>
       <_CoverageGitHubSummary>$([System.IO.Path]::Combine($(CoverageOutputPath), 'SummaryGithub.md'))</_CoverageGitHubSummary>

--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -125,6 +125,10 @@
       <_TestingPlatformCommandLineArguments Condition=" '$(CoverageOutput)' != '' ">$(_TestingPlatformCommandLineArguments) --coverage-output %22$(CoverageOutput)%22</_TestingPlatformCommandLineArguments>
       <_TestingPlatformCommandLineArguments Condition=" '$(CoverageRunSettings)' != '' ">$(_TestingPlatformCommandLineArguments) --coverage-settings %22$(CoverageRunSettings)%22</_TestingPlatformCommandLineArguments>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(IsGitHubActions)' == 'true' ">
+      <_TestingPlatformCommandLineArguments>$(_TestingPlatformCommandLineArguments) --report-junit</_TestingPlatformCommandLineArguments>
+      <_TestingPlatformCommandLineArguments>$(_TestingPlatformCommandLineArguments) --report-junit-filename %22$(MSBuildProjectName).$(TargetFramework).junit.xml%22</_TestingPlatformCommandLineArguments>
+    </PropertyGroup>
     <PropertyGroup Condition=" '@(TestingPlatformIgnoreExitCodes->Count())' &gt; 0 ">
       <_TestingPlatformCommandLineArguments>$(_TestingPlatformCommandLineArguments) --ignore-exit-code %22@(TestingPlatformIgnoreExitCodes->'%(Identity)', '%3B')%22</_TestingPlatformCommandLineArguments>
     </PropertyGroup>

--- a/src/BuildKit/build/Testing.targets
+++ b/src/BuildKit/build/Testing.targets
@@ -40,7 +40,7 @@
     <_ReportGeneratorOutputMarkdown Condition=" '$(IsGitHubActions)' == 'true' AND '$(GITHUB_STEP_SUMMARY)' != '' ">true</_ReportGeneratorOutputMarkdown>
     <CoverageFormat>$([MSBuild]::ValueOrDefault('$(CoverageFormat)', 'cobertura'))</CoverageFormat>
     <CoverageOutputPath>$([MSBuild]::ValueOrDefault('$(CoverageOutputPath)', '$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))'))</CoverageOutputPath>
-    <CoverageOutput>$([MSBuild]::ValueOrDefault('$(CoverageOutput)', '$([System.IO.Path]::Combine($(CoverageOutputPath), '$(MSBuildProjectName)', 'coverage.xml'))'))</CoverageOutput>
+    <CoverageOutput>$([MSBuild]::ValueOrDefault('$(CoverageOutput)', '$([System.IO.Path]::Combine($(CoverageOutputPath), '$(MSBuildProjectName)', 'coverage.$(TargetFramework).xml'))'))</CoverageOutput>
     <CoverletOutput>$([System.IO.Path]::Combine($(CoverageOutputPath), '$(MSBuildProjectName)', 'coverage'))</CoverletOutput>
   </PropertyGroup>
   <!-- Automatically exclude various common non-user code from coverage when using Coverlet -->


### PR DESCRIPTION
- Use TFM-specific file names for code coverage files.
- Automatically JUnit output with TFM-specific file names when running in GitHub Actions CI with MTP.
